### PR TITLE
Publish vscode extension to Visual Studio Marketplace

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,57 @@
+name: Release vscode extension
+
+on: 
+  release:
+    types: [published]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Checkout main branch
+      run: git checkout main
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      working-directory: ./fosslight-scanner
+      run: npm install
+
+    - name: Extract version from tag
+      id: extract_version
+      run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+      
+    - name: Update package version
+      working-directory: ./fosslight-scanner
+      run: npm version ${{ env.VERSION }} --no-git-tag-version
+
+    - name: Commit version change
+      run: |
+        git config --local user.name "github-actions[bot]"
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git add ./fosslight-scanner/package.json
+        git commit -m "Update version to ${{ env.VERSION }}"
+
+    - name: Push changes
+      run: git push origin HEAD:main
+      
+    - name: Install vsce
+      working-directory: ./fosslight-scanner
+      run: npm install -g vsce
+
+    - name: Publish VS Code Extension
+      working-directory: ./fosslight-scanner
+      env:
+        VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
+      run: |
+        vsce package
+        vsce publish


### PR DESCRIPTION
## Description
When a tag is created and a release is published, the GitHub Action is triggered. The action extracts the tag (version), updates the version field in the package.json, and then publishes the extension to the Visual Studio Code Marketplace using vsce.


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
