### PR TITLE
Streamline Extension Execution Commands

### DIFF
--- a/fosslight-scanner/package.json
+++ b/fosslight-scanner/package.json
@@ -34,12 +34,12 @@
       {
         "command": "fosslight-scanner.analyzeRootDirectory",
         "key": "ctrl+shift+r",
-        "when": "editorTextFocus"
+        "when": "editorFocus"
       },
       {
         "command": "fosslight-scanner.analyzeCurrentFile",
         "key": "ctrl+shift+c",
-        "when": "editorTextFocus"
+        "when": "editorFocus && !terminalFocus"
       }
     ]
   },

--- a/fosslight-scanner/package.json
+++ b/fosslight-scanner/package.json
@@ -29,6 +29,18 @@
         "command": "fosslight-scanner.analyzeCurrentFile",
         "title": "Analyze Current File"
       }
+    ],
+    "keybindings": [
+      {
+        "command": "fosslight-scanner.analyzeRootDirectory",
+        "key": "ctrl+shift+r",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "fosslight-scanner.analyzeCurrentFile",
+        "key": "ctrl+shift+c",
+        "when": "editorTextFocus"
+      }
     ]
   },
   "scripts": {


### PR DESCRIPTION
## Description
Previously, the extension had to be executed by opening the Command Palette in VSCode using Ctrl + Shift + P, and then manually selecting either 'analyze root directory' or 'analyze current file,' which was inconvenient. To simplify this process, I mapped 'analyze root directory' to Ctrl + Shift + R and 'analyze current file' to Ctrl + Shift + C, reducing the steps required to run these commands using keybindings.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
